### PR TITLE
Change profile names to STU1

### DIFF
--- a/src/fhir-resources.ts
+++ b/src/fhir-resources.ts
@@ -17,12 +17,12 @@ export const META_PROFILE_ECOG = "mcode-ecog-performance-status";
 export const META_PROFILE_KARNOFSKY = "mcode-karnofsky-performance-status";
 export const META_PROFILE_SECONDARY_CONDITION = "mcode-secondary-cancer-condition"; //Used for Metastasis
 export const META_PROFILE_MEDICATION_ADMINISTRATION = "mcode-cancer-related-medication-administration";
-export const META_PROFILE_MEDICATION_REQUEST = "mcode-cancer-related-medication-request";
+export const META_PROFILE_MEDICATION_REQUEST = "mcode-cancer-related-medication-statement";
 export const META_PROFILE_HISTOLOGY_MORPHOLOGY = "mcode-histology-morphology-behavior";
 export const META_PROFILE_GENOMIC_VARIANT = "mcode-genomic-variant";
-export const META_PROFILE_STAGE_GROUP = "mcode-cancer-stage-group";
+export const META_PROFILE_STAGE_GROUP = "mcode-tnm-clinical-stage-group";
 export const META_PROFILE_SURGICAL_PROCEDURE = "mcode-cancer-related-surgical-procedure";
-export const META_PROFILE_RADIOTHERAPY = "mcode-radiotherapy-course-summary";
+export const META_PROFILE_RADIOTHERAPY = "mcode-cancer-related-radiation-procedure";
 
 
 export const dictByFhirSystemMap = new Map<string, string>([

--- a/src/fhir-resources.ts
+++ b/src/fhir-resources.ts
@@ -5,9 +5,8 @@ export const FHIR_RESOURCES = {
     Patient: "Patient",
     Condition: "Condition",
     Observation: "Observation",
-    MedicationAdministration: "MedicationAdministration",
-    MedicationRequest: "MedicationRequest",
-    Procedure: "Procedure",
+    MedicationStatement: "MedicationStatement",
+    Procedure: "Procedure"
 }
 
 //Under http://hl7.org/fhir/us/mcode/StructureDefinition/ the following profiles defined.
@@ -16,8 +15,7 @@ export const META_PROFILE_BIO_MARKERS = "mcode-tumor-marker";
 export const META_PROFILE_ECOG = "mcode-ecog-performance-status";
 export const META_PROFILE_KARNOFSKY = "mcode-karnofsky-performance-status";
 export const META_PROFILE_SECONDARY_CONDITION = "mcode-secondary-cancer-condition"; //Used for Metastasis
-export const META_PROFILE_MEDICATION_ADMINISTRATION = "mcode-cancer-related-medication-administration";
-export const META_PROFILE_MEDICATION_REQUEST = "mcode-cancer-related-medication-statement";
+export const META_PROFILE_MEDICATION_STATEMENT = "mcode-cancer-related-medication-statement";
 export const META_PROFILE_HISTOLOGY_MORPHOLOGY = "mcode-histology-morphology-behavior";
 export const META_PROFILE_GENOMIC_VARIANT = "mcode-genomic-variant";
 export const META_PROFILE_STAGE_GROUP = "mcode-tnm-clinical-stage-group";

--- a/src/mappers.ts
+++ b/src/mappers.ts
@@ -22,8 +22,7 @@ import {
     META_PROFILE_GENOMIC_VARIANT,
     META_PROFILE_HISTOLOGY_MORPHOLOGY,
     META_PROFILE_KARNOFSKY,
-    META_PROFILE_MEDICATION_ADMINISTRATION,
-    META_PROFILE_MEDICATION_REQUEST,
+    META_PROFILE_MEDICATION_STATEMENT,
     META_PROFILE_SECONDARY_CONDITION,
     META_PROFILE_STAGE_GROUP,
     META_PROFILE_SURGICAL_PROCEDURE,
@@ -46,8 +45,7 @@ import {
     Bundle,
     Condition,
     FhirResource,
-    MedicationAdministration,
-    MedicationRequest,
+    MedicationStatement,
     Observation,
     Parameters,
     Patient,
@@ -427,7 +425,7 @@ function mapECOG(fhirResources: Map<string, FhirResource[]>, apiRequest: CbApiRe
 
 function mapDrugs(fhirResources: Map<string, FhirResource[]>, apiRequest: CbApiRequest) {
 
-    const medAdminResources = fhirResources.get(FHIR_RESOURCES.MedicationAdministration);
+    const medStatementResources = fhirResources.get(FHIR_RESOURCES.MedicationStatement);
     const categoryData = categoriesMap.get(CATEGORY_DRUGS);
     const drugItem: CbEligibilityFields = {
         fieldId: categoryData.id,
@@ -435,14 +433,14 @@ function mapDrugs(fhirResources: Map<string, FhirResource[]>, apiRequest: CbApiR
         values: []
     };
 
-    if(medAdminResources) {
-        const medAdminProfiles = medAdminResources.filter(resource => {
-            return resource.meta?.profile?.some(elem => elem.includes(META_PROFILE_MEDICATION_ADMINISTRATION));
+    if(medStatementResources) {
+        const medStatementProfiles = medStatementResources.filter(resource => {
+            return resource.meta?.profile?.some(elem => elem.includes(META_PROFILE_MEDICATION_STATEMENT));
         });
 
-        if(medAdminProfiles?.length > 0) {
-            medAdminProfiles.forEach(res => {
-                for (const coding of (res as MedicationAdministration).medicationCodeableConcept.coding) {
+        if(medStatementProfiles?.length > 0) {
+            medStatementProfiles.forEach(res => {
+                for (const coding of (res as MedicationStatement).medicationCodeableConcept.coding) {
                     const drugValue: CbValueFields = {
                         valueSetId: getDictionaryBySystemCode(coding.system),
                         valueId: coding.code
@@ -452,37 +450,12 @@ function mapDrugs(fhirResources: Map<string, FhirResource[]>, apiRequest: CbApiR
             });
         }
         else {
-            console.warn("FHIR Bundle: Found MedicationAdministration Resource: Missing MedicationAdministration with meta.Profile field: " + META_PROFILE_MEDICATION_ADMINISTRATION);
+            console.warn("FHIR Bundle: Found MedicationStatement Resource: Missing MedicationStatement with meta.Profile field: " + META_PROFILE_MEDICATION_STATEMENT);
         }
 
     }
     else {
-        console.log("FHIR Bundle: missing MedicationAdministration resource.");
-    }
-
-    const medResources = fhirResources.get(FHIR_RESOURCES.MedicationRequest);
-    if(medResources) {
-        const medReqProfiles = medResources.filter(resource => {
-            return resource.meta?.profile?.some(elem => elem.includes(META_PROFILE_MEDICATION_REQUEST));
-        });
-
-        if(medReqProfiles?.length > 0) {
-            medReqProfiles.forEach(res => {
-                for (const coding of (res as MedicationRequest).medicationCodeableConcept.coding) {
-                    const drugValue: CbValueFields = {
-                        valueSetId: getDictionaryBySystemCode(coding.system),
-                        valueId: coding.code
-                    };
-                    drugItem.values.push(drugValue);
-                }
-            });
-        }
-        else {
-            console.warn("FHIR Bundle: Found MedicationRequest Resource: Missing MedicationRequest with meta.Profile field: " + META_PROFILE_MEDICATION_REQUEST);
-        }
-    }
-    else {
-        console.log("FHIR Bundle: missing MedicationRequest resource.");
+        console.log("FHIR Bundle: missing MedicationStatement resource.");
     }
 
     if(drugItem.values.length > 0) {


### PR DESCRIPTION
Changed profile names to match those used in the app.

Can compare with `src/utils/fhirConstants.ts` in app repository.

NOTE:
Found no replacement for:
* `export const META_PROFILE_MEDICATION_ADMINISTRATION = "mcode-cancer-related-medication-administration";`
* `export const META_PROFILE_GENOMIC_VARIANT = "mcode-genomic-variant";`