### PR TITLE
Remove cp command from build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.1.3",
-        "clinical-trial-matching-service": "^0.0.7",
+        "clinical-trial-matching-service": "^0.0.8",
         "csv-parse": "^5.3.2",
         "dotenv-flow": "^3.2.0"
       },
@@ -18,7 +18,7 @@
         "@istanbuljs/nyc-config-typescript": "^1.0.1",
         "@types/dotenv-flow": "^3.0.0",
         "@types/express": "^4.17.12",
-        "@types/fhir": "^0.0.35",
+        "@types/fhir": "^0.0.36",
         "@types/jasmine": "^4.3.1",
         "@types/node": "^18.11.17",
         "@types/supertest": "^2.0.9",
@@ -832,9 +832,9 @@
       }
     },
     "node_modules/@types/fhir": {
-      "version": "0.0.35",
-      "resolved": "https://registry.npmjs.org/@types/fhir/-/fhir-0.0.35.tgz",
-      "integrity": "sha512-y+VI3Y48xzZBM8AjXPq67EWbiY9VN4Cx5KzN8EplS0Zju8D2KahLXoK6P/PWlKyNTKvJBwemkHzJIocczLRkhQ==",
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@types/fhir/-/fhir-0.0.36.tgz",
+      "integrity": "sha512-Krjb/2zKlJFjVkEPvs5QFjoYynDF2NaflR8fl4KREgJsvvHG7jrSrLdlS4zTB8E+1MgI1g0fWsz0FzniYmJlMg==",
       "dev": true
     },
     "node_modules/@types/jasmine": {
@@ -1459,14 +1459,14 @@
       }
     },
     "node_modules/clinical-trial-matching-service": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/clinical-trial-matching-service/-/clinical-trial-matching-service-0.0.7.tgz",
-      "integrity": "sha512-yvSs+Mu+0pDaYqY1HaJT8UgYCW/yOrfxMg+D5GHqOstozUC6qry0vVjuxA5RNTDfbGt33S8QN240jr8tdCY8CQ==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/clinical-trial-matching-service/-/clinical-trial-matching-service-0.0.8.tgz",
+      "integrity": "sha512-lwIW0tQkL2QL1/H5J+S/9LxWmhou1wtockCFQX//0M2rqV7B8fKxJrpSsLy0bVM1qzMHZQfVKv/xZNHi5O8jMQ==",
       "dependencies": {
         "body-parser": "^1.19.0",
         "express": "^4.17.1",
         "fhirpath": "^3.3.0",
-        "xml2js": "^0.4.23",
+        "xml2js": "^0.5.0",
         "yauzl": "^2.10.0"
       }
     },
@@ -4634,9 +4634,9 @@
       }
     },
     "node_modules/xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "axios": "^1.1.3",
-    "clinical-trial-matching-service": "^0.0.7",
+    "clinical-trial-matching-service": "^0.0.8",
     "csv-parse": "^5.3.2",
     "dotenv-flow": "^3.2.0"
   },
@@ -27,7 +27,7 @@
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "@types/dotenv-flow": "^3.0.0",
     "@types/express": "^4.17.12",
-    "@types/fhir": "^0.0.35",
+    "@types/fhir": "^0.0.36",
     "@types/jasmine": "^4.3.1",
     "@types/node": "^18.11.17",
     "@types/supertest": "^2.0.9",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,9 @@
   "description": "",
   "main": "dist/server.js",
   "scripts": {
-    "build": "npm run-script build:ts && npm run-script copy:csv",
+    "build": "npm run-script build:ts",
     "build:tests": "tsc --build tsconfig.test.json",
     "build:ts": "tsc",
-    "copy:csv": "cp ./data/* ./dist/",
     "coverage": "npm run-script build:tests && nyc --require ts-node/register --reporter=lcovonly jasmine",
     "coverage:html": "npm run-script build:tests && nyc --require ts-node/register --reporter=html jasmine",
     "lint": "eslint . --ext .js,.ts",

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -12,7 +12,7 @@ export type UsZip = {
 };
 
 export const zipCodeToLatLngMapping = new Map<string, UsZip>(); //Loaded dynamically based on csv file
-export const US_ZIPCODES_FILE = "../data/uszips.csv";
+export const US_ZIPCODES_FILE = "../../data/uszips.csv";
 
 
 export function importUsZipFile(filePath: string, mapping: Map<string, UsZip>){

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -12,7 +12,7 @@ export type UsZip = {
 };
 
 export const zipCodeToLatLngMapping = new Map<string, UsZip>(); //Loaded dynamically based on csv file
-export const US_ZIPCODES_FILE = "../../data/uszips.csv";
+export const US_ZIPCODES_FILE = "../data/uszips.csv";
 
 
 export function importUsZipFile(filePath: string, mapping: Map<string, UsZip>){


### PR DESCRIPTION
Updates the dependencies to the versions required to run in IIS, removes a `cp` command that breaks the wrapper on Windows.